### PR TITLE
fix: patch smallbitvec vulnerability (CVE-2026-44983)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6367,9 +6367,9 @@ dependencies = [
 
 [[package]]
 name = "smallbitvec"
-version = "2.5.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e"
+checksum = "9b0e903ee191d8f7a8fbf0d712c3a1699d19e04ceba5ad1eb673053c7d938a09"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
## Summary
Upgrade smallbitvec from 2.5.1 to None to fix CVE-2026-44983.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-44983 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-44983` |
| **File** | `rust/Cargo.lock` (dependency: `smallbitvec`) |
| **Assessment** | Likely exploitable |

**Description**: smallbitvec is a growable bit-vector for Rust, optimized for size. Fro ...

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-44983` flagged this pattern.

## Changes
- `rust/Cargo.lock`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
